### PR TITLE
Add role for creation of IAM account, policy, S3 storage

### DIFF
--- a/roles/create_aws_backup_storage/tasks/main.yml
+++ b/roles/create_aws_backup_storage/tasks/main.yml
@@ -1,0 +1,34 @@
+- name: Get AWS account information
+  aws_caller_facts:
+  register: caller_facts
+
+- name: Retrieve AWS account identifier (ARN) for use in resource tags
+  set_fact:
+    aws_arn: "{{ caller_facts.arn }}"
+    aws_resource_name: "velero-{{ caller_facts.arn | hash('md5') }}"
+
+- name: Create S3 bucket for backup storage of OpenShift resource definitions
+  s3_bucket:
+    state: present
+    name: "{{ aws_resource_name }}"
+    tags:
+      owner: "{{ aws_arn }}"
+
+- name: Create IAM user for Velero to assume role of
+  iam_user:
+    state: present
+    name: "{{ aws_resource_name }}"
+
+- name: Create IAM policy entitling Velero user access to S3 bucket and EBS volume storage
+  iam_policy:
+    state: present
+    iam_type: user
+    iam_name: "{{ aws_resource_name }}"
+    policy_name: "{{ aws_resource_name }}"
+    policy_json: "{{ lookup( 'template', 'velero_policy.json.j2') }}"
+
+
+
+
+
+

--- a/roles/create_aws_backup_storage/templates/velero_policy.json.j2
+++ b/roles/create_aws_backup_storage/templates/velero_policy.json.j2
@@ -1,0 +1,39 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeVolumes",
+                "ec2:DescribeSnapshots",
+                "ec2:CreateTags",
+                "ec2:CreateVolume",
+                "ec2:CreateSnapshot",
+                "ec2:DeleteSnapshot"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:DeleteObject",
+                "s3:PutObject",
+                "s3:AbortMultipartUpload",
+                "s3:ListMultipartUploadParts"
+            ],
+            "Resource": [
+                "arn:aws:s3:::{{ aws_resource_name }}/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::{{ aws_resource_name }}"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Ansible role for creation of required AWS IAM user / policy + S3 bucket needed for backing up to resource definitions to S3 and persistent volumes to EBS.

This PR does _not_ include pieces needed for configuring Velero to actually _use_ any of the created items. 

All resources are uniquely named, so each set of AWS login credentials used to run this playbook should yield a separate bucket/IAM user/policy.

Still need to add recording of the AWS access/secret key for the new user to be plugged into the "cloud-credentials" k8s secret.