### PR TITLE
Lookup EC2 creds from ENV and update for running on MacOS

### DIFF
--- a/config/defaults.yml
+++ b/config/defaults.yml
@@ -1,8 +1,8 @@
-aws_access_key_id:
-aws_secret_access_key:
+aws_access_key_id: "{{ lookup('env','AWS_ACCESS_KEY_ID') }}"
+aws_secret_access_key: "{{ lookup('env','AWS_SECRET_ACCESS_KEY') }}"
 pullSecret: "{{ lookup('file', '{{ playbook_dir }}/config/pull-secret') | from_json }}" # Do not modify this line
-sshKey: ""
+sshKey: "{{ lookup('file', '~/.ssh/libra_rsa.pub')  }}"
 baseDomain: mg.dog8code.com # Default mg.dog8code.com
 masterReplicas: 1 # Default 1
 workerReplicas: 1 # Default 1
-awsRegion: us-east-2 # Default us-east-2
+awsRegion: "{{ lookup('env','AWS_DEFAULT_REGION') or 'us-east-2' }}"   # Default us-east-2

--- a/roles/install_ocp_installer/tasks/main.yml
+++ b/roles/install_ocp_installer/tasks/main.yml
@@ -1,6 +1,18 @@
 ---
+- set_fact:
+    openshift_installer_release: "v0.12.0"
+    openshift_installer_release_type: "linux"
+
+- name: Setting openshift-installer facts for MacOS
+  set_fact:
+    openshift_installer_release_type: "darwin"
+  when: ansible_os_family == "Darwin"
+
+- set_fact:
+    openshift_installer_release_url: "https://github.com/openshift/installer/releases/download/{{ openshift_installer_release }}/openshift-install-{{ openshift_installer_release_type }}-amd64"
+
 - name: get installer
   get_url:
-    url: https://github.com/openshift/installer/releases/download/v0.11.0/openshift-install-linux-amd64
+    url: "{{ openshift_installer_release_url }}"
     dest: "{{ playbook_dir }}/openshift-install"
     mode: 0775


### PR DESCRIPTION
Still testing, let's wait a bit to merge.

This is intended to lookup the AWS credentials from the environment so a user doesn't need to add them to defaults.yml.   

Also has some tweaks to help run this from MacOS

