### PR TITLE
Remove k8s lookup, use k8s_facts which does not require manual env var setting

### DIFF
--- a/roles/create_nginx_app_with_backup/tasks/main.yml
+++ b/roles/create_nginx_app_with_backup/tasks/main.yml
@@ -12,7 +12,7 @@
     label_selectors:
       - "app = nginx"
   register: deploy
-  until: deploy and deploy.resources[0].status.replicas == deploy.resources[0].status.get("availableReplicas", 0)
+  until: deploy and (deploy.resources | length > 0) and (deploy.resources[0].status.replicas == deploy.resources[0].status.get("availableReplicas", 0))
   retries: 10
   delay: 10
 
@@ -27,6 +27,6 @@
     kind: "Backup"
     namespace: "heptio-ark"
   register: backup
-  until: backup and backup.resources[0].status.get("phase", 0) == "Completed"
+  until: backup and (backup.resources | length > 0) and (backup.resources[0].status.get("phase", 0) == "Completed")
   retries: 10
   delay: 5

--- a/roles/create_nginx_app_with_backup/tasks/main.yml
+++ b/roles/create_nginx_app_with_backup/tasks/main.yml
@@ -12,9 +12,9 @@
     label_selectors:
       - "app = nginx"
   register: deploy
-  until: deploy and (deploy.resources | length > 0) and (deploy.resources[0].status.replicas == deploy.resources[0].status.get("availableReplicas", 0))
-  retries: 10
-  delay: 10
+  until: deploy
+         and (deploy.resources | length > 0)
+         and (deploy.resources[0].get("status", {}).get("replicas",-1) == deploy.resources[0].get("status", {}).get("availableReplicas", -2))
 
 - name: Create ark backup of nginx
   k8s:
@@ -27,6 +27,9 @@
     kind: "Backup"
     namespace: "heptio-ark"
   register: backup
-  until: backup and (backup.resources | length > 0) and (backup.resources[0].status.get("phase", 0) == "Completed")
+  until: backup
+         and (backup.resources | length > 0)
+         and (backup.resources[0].get("status", {}).get("phase", 0) == "Completed")
   retries: 10
   delay: 5
+

--- a/roles/create_nginx_app_with_backup/tasks/main.yml
+++ b/roles/create_nginx_app_with_backup/tasks/main.yml
@@ -3,34 +3,30 @@
   k8s:
     state: "{{ state }}"
     definition: "{{ lookup('file', 'base.yaml')}}"
+
 - name: Wait 2 minutes for nginx deployment
-  debug:
-    var: deploy
-  until: deploy and deploy.status.replicas == deploy.status.get("availableReplicas", 0)
+  k8s_facts:
+    api_version: "apps/v1"
+    kind: "Deployment"
+    namespace: "nginx-example"
+    label_selectors:
+      - "app = nginx"
+  register: deploy
+  until: deploy and deploy.resources[0].status.replicas == deploy.resources[0].status.get("availableReplicas", 0)
   retries: 10
   delay: 10
-  vars:
-    deploy: '{{ lookup("k8s",
-      kind="Deployment",
-      api_version="apps/v1",
-      namespace="nginx-example",
-      label_selector="app=nginx"
-    )}}'
 
 - name: Create ark backup of nginx
   k8s:
     state : "{{ state }}"
     definition: "{{ lookup('file', 'create-backup.yml')}}"
-- name: Wait for backup to complete
-  debug:
-    var: backup
-  until: backup and backup.status.get("phase", 0) == "Completed"
+
+- name: Wait 1 minute for backup to complete
+  k8s_facts:
+    api_version: "ark.heptio.com/v1"
+    kind: "Backup"
+    namespace: "heptio-ark"
+  register: backup
+  until: backup and backup.resources[0].status.get("phase", 0) == "Completed"
   retries: 10
   delay: 5
-  vars:
-    backup: '{{ lookup("k8s",
-      kind="Backup",
-      api_version="ark.heptio.com/v1",
-      namespace="heptio-ark"
-    )}}'
-

--- a/roles/delete_nginx_and_restore/tasks/main.yml
+++ b/roles/delete_nginx_and_restore/tasks/main.yml
@@ -33,7 +33,9 @@
     namespace: "heptio-ark"
     name: "nginx-backup"
   register: restore
-  until: restore and (restore.resources | length > 0) and (restore.resources[0].status.get("phase", 0) == "Completed")
+  until: restore
+         and (restore.resources | length > 0)
+         and (restore.resources[0].get("status", {}).get("phase", 0) == "Completed")
   retries: 20
   delay: 10
 
@@ -45,7 +47,9 @@
     label_selectors:
       - "app = nginx"
   register: deploy
-  until: deploy and (deploy.resources | length > 0) and (deploy.resources[0].status.replicas == deploy.resources[0].status.get("availableReplicas", 0))
+  until: deploy
+         and (deploy.resources | length > 0)
+         and (deploy.resources[0].get("status", {}).get("replicas", -1) == deploy.resources[0].get("status", {}).get("availableReplicas", -2))
   retries: 10
   delay: 10
 

--- a/roles/delete_nginx_and_restore/tasks/main.yml
+++ b/roles/delete_nginx_and_restore/tasks/main.yml
@@ -11,50 +11,44 @@
           app: nginx
 
 - name: Wait 2 minutes for namespace to be deleted
-  debug:
-    var: ns
-  until:  not ns
+  k8s_facts:
+    api_version: "v1"
+    kind: "Namespace"
+    namespace: "nginx-example"
+    name: "nginx-example"
+  register: ns
+  until: not ns
   retries: 10
   delay: 5
-  vars:
-    ns: '{{ lookup("k8s",
-      kind="Namespace",
-      api_version="v1",
-      resource_name="nginx-example"
-    )}}'
+
 
 - name: Create ark restore of nginx
   k8s:
     state: present
     definition: "{{ lookup('file', 'create-restore.yml')}}"
 
-- name: Wait for restore to finish
-  debug:
-    var: restore
-  until: restore and restore.status.get("phase", 0) == "Completed"
+- name: Wait 3 minutes for restore to finish
+  k8s_facts:
+    api_version: "apps/v1"
+    kind: "Restore"
+    namespace: "heptio-ark"
+    name: "nginx-backup"
+  register: restore
+  until: restore and restore[0].status.get("phase", 0) == "Completed"
   retries: 20
   delay: 10
-  vars:
-    restore: '{{ lookup("k8s",
-      kind="Restore",
-      api_version="ark.heptio.com/v1",
-      namespace="heptio-ark",
-      resource_name="nginx-backup"
-    )}}'
 
-- name: Wait for nginx deployment
-  debug:
-    var: deploy
-  until: deploy and deploy.status.replicas == deploy.status.get("availableReplicas", 0)
+- name: Wait 2 minutes for nginx deployment
+  k8s_facts:
+    api_version: "apps/v1"
+    kind: "Deployment"
+    namespace: "nginx-example"
+    label_selectors:
+      - "app = nginx"
+  register: deploy
+  until: deploy and deploy.resources[0].status.replicas == deploy.resources[0].status.get("availableReplicas", 0)
   retries: 10
   delay: 10
-  vars:
-    deploy: '{{ lookup("k8s",
-      kind="Deployment",
-      api_version="apps/v1",
-      namespace="nginx-example",
-      label_selector="app=nginx"
-    )}}'
 
 - name: Delete ark restore of nginx (workaround to use common name for restore)
   k8s:

--- a/roles/delete_nginx_and_restore/tasks/main.yml
+++ b/roles/delete_nginx_and_restore/tasks/main.yml
@@ -17,10 +17,9 @@
     namespace: "nginx-example"
     name: "nginx-example"
   register: ns
-  until: not ns
+  until: ns.resources | length == 0
   retries: 10
   delay: 5
-
 
 - name: Create ark restore of nginx
   k8s:
@@ -29,24 +28,24 @@
 
 - name: Wait 3 minutes for restore to finish
   k8s_facts:
-    api_version: "apps/v1"
+    api_version: "v1"
     kind: "Restore"
     namespace: "heptio-ark"
     name: "nginx-backup"
   register: restore
-  until: restore and restore[0].status.get("phase", 0) == "Completed"
+  until: restore and (restore.resources | length > 0) and (restore.resources[0].status.get("phase", 0) == "Completed")
   retries: 20
   delay: 10
 
 - name: Wait 2 minutes for nginx deployment
   k8s_facts:
-    api_version: "apps/v1"
+    api_version: "v1"
     kind: "Deployment"
     namespace: "nginx-example"
     label_selectors:
       - "app = nginx"
   register: deploy
-  until: deploy and deploy.resources[0].status.replicas == deploy.resources[0].status.get("availableReplicas", 0)
+  until: deploy and (deploy.resources | length > 0) and (deploy.resources[0].status.replicas == deploy.resources[0].status.get("availableReplicas", 0))
   retries: 10
   delay: 10
 


### PR DESCRIPTION
# Overview
Moves from using the k8s lookup plugin to the k8s_facts module.

This change removes the dependency on whatever the user has set for the `KUBECONFIG` environment variable before running the playbook. With k8s_facts, the playbook will _always_ use the values in `auth/kubeconfig` (since we set them in the environment https://github.com/fusor/ocp-velero-ansible/blob/master/create-nginx.yml#L4-L5) created by openshift-installer. 

# Why
Before this PR, the playbook outputs a kubeconfig path that will be "used" for the duration of the playbook...
```
TASK [login_ocp : debug] ****************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "Logging into cluster using KUBECONFIG: /home/dwhatley/dev/ocp-velero-ansible/auth/kubeconfig"
}
```
... but in reality all calls to lookup plugins (including the k8s lookup plugin) will use whatever `KUBECONFIG` env var you have set in your local environment. This leads to a confusing error condition where some tasks will run successfully but others won't if you have a bad KUBECONFIG set in your env.

Below is an example of what you might see on a task that uses the lookup plugin if your `KUBECONFIG` env var wasn't set properly before running the playbook.
```
TASK [create_nginx_app_with_backup : Wait 2 minutes for nginx deployment] ********************************************************************************************************************
2019-02-15 13:20:32,652 WARNING Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NewConnectionError('<urllib3.connection.VerifiedHTTPSConnection object at 0x7fb05437d350>: Failed to establish a new connection: [Errno 113] No route to host',)': /version
```

## Notes / Testing Needs
I haven't been able to execute a successful backup on my workstation yet, so both of the changed roles still need testing before merge. Hopefully whoever has a working environment can give them a shot.
