### PR TITLE
Set prefix to use subdir in s3 bucket

### DIFF
--- a/roles/launch_velero/templates/05-ark-aws-backupstoragelocation.yaml.j2
+++ b/roles/launch_velero/templates/05-ark-aws-backupstoragelocation.yaml.j2
@@ -22,5 +22,6 @@ spec:
   provider: aws
   objectStorage:
     bucket: {{ velero_aws_bucket_name }}
+    prefix: velero-backups
   config:
     region: {{ aws_region }}

--- a/roles/launch_velero/templates/05-ark-minio-backupstoragelocation.yaml.j2
+++ b/roles/launch_velero/templates/05-ark-minio-backupstoragelocation.yaml.j2
@@ -8,6 +8,7 @@ spec:
   provider: aws
   objectStorage:
     bucket: velero
+    prefix: velero-backups
   config:
     region: minio
     s3ForcePathStyle: "true"


### PR DESCRIPTION
Putting the velero backups in a subdir of the bucket
removes the need to modify velero to coexist with the
registry top level dir, since 'registry' and 'velero-backups'
will be at the same level now.

Once this is merged we can revert the commit on fusor/velero which allows for the extra registry dir.